### PR TITLE
fix: corrige CSP bloqueando Google Fonts e erros de compilação no Render

### DIFF
--- a/src/db/db.ts
+++ b/src/db/db.ts
@@ -2,7 +2,7 @@ import mongoose from 'mongoose';
 
 export default async function connectDB() : Promise<void> {
     try {
-        await mongoose.connect(process.env.MONGODB_URI as string, {});
+        await mongoose.connect(process.env.MONGODB_URI as string);
         console.log('Conectado ao MongoDB com sucesso');
     } catch (error) {
         console.log('Erro ao conectar ao MongoDB:', error);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "jsx": "react-jsx",
 
     "isolatedModules": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "types": ["node"]
   },
 
   "include": ["src/**/*", "src/views/**/*"],


### PR DESCRIPTION
## O que esse PR faz

Corrige dois problemas introduzidos pelo sprint de security hardening que quebraram o deploy no Render e o carregamento das fontes Pacifico e Material Symbols na interface.

**Problema 1 — CSP bloqueando fontes externas (`src/index.ts`)**  
A política do helmet não declarava `fontSrc`, fazendo o browser herdar `defaultSrc: 'self'` e rejeitar os arquivos `.woff2` de `fonts.gstatic.com`. Além disso, `styleSrc` não incluía `fonts.googleapis.com`, bloqueando o CSS de `@font-face` antes mesmo do download das fontes. Adicionadas as diretivas `fontSrc`, `imgSrc` e as origens faltantes em `styleSrc` e `scriptSrc`.

**Problema 2 — Erros de compilação TypeScript no Render (`tsconfig.json`, `src/db/db.ts`)**  
Faltava `"types": ["node"]` no `tsconfig.json`; sem isso o TypeScript 5.x não expõe os globals do Node (`process`, `__dirname`, `crypto`, `fs`, `path`) mesmo com `@types/node` instalado. Os erros de `AuthRequest.headers/body` eram cascata desse problema. Também removido o `{}` de `mongoose.connect()`, que o Mongoose 8 rejeita com `exactOptionalPropertyTypes: true` ativo.

## Checklist

### Código
- [x] Funcionalidade testada manualmente no fluxo principal
- [x] Casos de borda considerados

### Documentação
- [x] Esta mudança **não** atende ao critério de plano escrito¹

### Segurança *(marcar se aplicável)*
- [x] Nenhuma rota nova exposta sem autenticação sem justificativa
- [x] Inputs de usuário validados e sanitizados
- [x] Nenhum segredo hardcoded
